### PR TITLE
feat: 머지 확인 브랜치 설정 분리

### DIFF
--- a/build-server-service/action.yml
+++ b/build-server-service/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 작업 디렉토리
     default: '.'
     type: string
+  merge_check_branch:
+    description: 배포 전 머지가 되었는지를 확인할 브랜치
+    type: string
   production_branch:
     description: 운영 환경 배포를 하는 브랜치
     required: true
@@ -73,7 +76,7 @@ runs:
   steps:
     - uses: croquiscom/github-actions/check-branch-up-to-date@main
       with:
-        required_branch: ${{ inputs.production_branch }}
+        required_branch: ${{ inputs.merge_check_branch || inputs.production_branch }}
 
     - name: Check branch is production branch (production)
       shell: bash


### PR DESCRIPTION
Production 브랜치와 머지를 확인해야할 브랜치가 서로 다른 경우가 있어, 이를 커버할 수 있도록 설정 값을 분리했습니다.

development 브랜치 -> main 으로 머지 하는 경우, main 브랜치는 프로덕션 브랜치이나, 실질적으로 머지를 채크해야하는 브랜치는 development 브랜치라... 이를 커버하고자 했습니다.