### PR TITLE
feat:  add production branch merge check skip inputs

### DIFF
--- a/build-server-service/action.yml
+++ b/build-server-service/action.yml
@@ -20,6 +20,9 @@ inputs:
   check_alpha_beta_branch:
     description: 알파, 베타 브랜치 체크 여부
     type: string
+  skip_check_production_branch:
+    description: 운영 환경 배포를 하는 브랜치 merge 체크 여부
+    type: string
   user_name:
     description: 배포한 사용자
     required: true
@@ -91,6 +94,7 @@ runs:
       run: echo $OUTPUTS
 
     - uses: croquiscom/github-actions/check-branch-up-to-date@main
+      if: inputs.skip_check_production_branch != 'true'
       with:
         required_branch: ${{ inputs.production_branch }}
         check_branch: ${{ inputs.branch }}


### PR DESCRIPTION
- build server service의 운영 환경 배포를 하는 브랜치 merge 체크를 스킵할 수 있는 변수를 추가했습니다.
- 기존 actions만으로 모두 스킵이 어려워 해당 액션을 추가하게 되었습니다.